### PR TITLE
BUGFIX: Default values should be passed to `$extension->getConfig`

### DIFF
--- a/src/David/HybridAuth/DI/HybridAuthExtension.php
+++ b/src/David/HybridAuth/DI/HybridAuthExtension.php
@@ -10,11 +10,11 @@ namespace David\HybridAuth\DI;
 class HybridAuthExtension extends \Nette\DI\CompilerExtension
 {
     /** @var array */
-    public $config = [];
+    public $defaults = [];
 
     public function loadConfiguration()
     {
-        $config = $this->getConfig($this->config);
+        $config = $this->getConfig($this->defaults);
 
         $builder = $this->getContainerBuilder();
         $builder->addDefinition($this->prefix('service'))


### PR DESCRIPTION
BUGFIX: Default values should be passed to `$extension->getConfig` instead of the config values: https://doc.nette.org/en/2.4/di-extensions#toc-compilerextension-loadconfiguration .

How to reproduce this BUG:
Add indexed array to neon. It will be merged with itself in `$extension->getConfig` and resulting array will contain every item twice.
